### PR TITLE
Convert tiny-process-library in a cmake library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,21 +6,23 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall")
 
 find_package(Threads REQUIRED)
 
-set(process_source_files ${CMAKE_SOURCE_DIR}/process.cpp)
+set(process_source_files process.cpp)
 
 if(WIN32)
-  list(APPEND process_source_files ${CMAKE_SOURCE_DIR}/process_win.cpp)
+  list(APPEND process_source_files process_win.cpp)
   #If compiled using MSYS2, use sh to run commands
   if(MSYS)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DMSYS_PROCESS_USE_SH")
   endif()
 else()
-  list(APPEND process_source_files ${CMAKE_SOURCE_DIR}/process_unix.cpp)
+  list(APPEND process_source_files process_unix.cpp)
 endif()
 
-add_executable(examples examples.cpp ${process_source_files})
+add_library(tiny-process-library ${process_source_files})
+add_executable(examples examples.cpp)
 
-target_link_libraries(examples ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(tiny-process-library ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(examples tiny-process-library)
 
 # To enable tests: cmake -DENABLE_TESTING=1 .
 if(ENABLE_TESTING)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,10 +1,10 @@
 include_directories(..)
 
-add_executable(open_close_test open_close_test.cpp ${process_source_files})
-target_link_libraries(open_close_test ${CMAKE_THREAD_LIBS_INIT})
+function(add_tiny_test name)
+  add_executable(${name} ${name}.cpp)
+  target_link_libraries(${name} tiny-process-library)
+  add_test(${name} ${name})
+endfunction()
 
-add_executable(multithread_test multithread_test.cpp ${process_source_files})
-target_link_libraries(multithread_test ${CMAKE_THREAD_LIBS_INIT})
-
-add_test(open_close_test open_close_test)
-add_test(multithread_test multithread_test)
+add_tiny_test(open_close_test)
+add_tiny_test(multithread_test)


### PR DESCRIPTION
In this way we can use target_link_libraries() to use tiny-process-library
on our own executable targets.

Also we've remove CMAKE_SOURCE_DIR because we need to search for
tiny-process-library source files in the current source dir (instead of
the root global source dir, which could be other if we use
tiny-process-library as a submodule).