### PR TITLE
Create a handle wrapper to avoid calling CloseHandle() several times

### DIFF
--- a/process_win.cpp
+++ b/process_win.cpp
@@ -20,7 +20,7 @@ public:
   }
   HANDLE detach() {
     HANDLE old_handle = handle;
-    handle = nullptr;
+    handle = INVALID_HANDLE_VALUE;
     return old_handle;
   }
   operator HANDLE() const { return handle; }


### PR DESCRIPTION
Something similar could be done for file descriptors in the unix port (to avoid calling `close(...)`).