### PR TITLE
On Windows, double check to avoid calling CloseHandle on not initiali…

### DIFF
--- a/process_win.cpp
+++ b/process_win.cpp
@@ -11,11 +11,11 @@ std::mutex create_process_mutex;
 //Based on the example at https://msdn.microsoft.com/en-us/library/windows/desktop/ms682499(v=vs.85).aspx.
 Process::id_type Process::open(const std::string &command, const std::string &path) {
   if(open_stdin)
-    stdin_fd=std::unique_ptr<fd_type>(new fd_type);
+    stdin_fd=std::unique_ptr<fd_type>(new fd_type(NULL));
   if(read_stdout)
-    stdout_fd=std::unique_ptr<fd_type>(new fd_type);
+    stdout_fd=std::unique_ptr<fd_type>(new fd_type(NULL));
   if(read_stderr)
-    stderr_fd=std::unique_ptr<fd_type>(new fd_type);
+    stderr_fd=std::unique_ptr<fd_type>(new fd_type(NULL));
 
   HANDLE stdin_rd_p = NULL;
   HANDLE stdin_wr_p = NULL;
@@ -192,11 +192,11 @@ void Process::close_fds() {
   
   if(stdin_fd)
     close_stdin();
-  if(stdout_fd) {
+  if(stdout_fd && *stdout_fd != NULL) {
     CloseHandle(*stdout_fd);
     stdout_fd.reset();
   }
-  if(stderr_fd) {
+  if(stderr_fd && *stderr_fd != NULL) {
     CloseHandle(*stderr_fd);
     stderr_fd.reset();
   }
@@ -222,7 +222,7 @@ bool Process::write(const char *bytes, size_t n) {
 
 void Process::close_stdin() {
   std::lock_guard<std::mutex> lock(stdin_mutex);
-  if(stdin_fd) {
+  if(stdin_fd && *stdin_fd != NULL) {
     CloseHandle(*stdin_fd);
     stdin_fd.reset();
   }

--- a/process_win.cpp
+++ b/process_win.cpp
@@ -192,12 +192,12 @@ void Process::close_fds() {
   
   if(stdin_fd)
     close_stdin();
-  if(stdout_fd && *stdout_fd != NULL) {
-    CloseHandle(*stdout_fd);
+  if(stdout_fd) {
+    if(*stdout_fd!=NULL) CloseHandle(*stdout_fd);
     stdout_fd.reset();
   }
-  if(stderr_fd && *stderr_fd != NULL) {
-    CloseHandle(*stderr_fd);
+  if(stderr_fd) {
+    if(*stderr_fd!=NULL) CloseHandle(*stderr_fd);
     stderr_fd.reset();
   }
 }
@@ -222,8 +222,8 @@ bool Process::write(const char *bytes, size_t n) {
 
 void Process::close_stdin() {
   std::lock_guard<std::mutex> lock(stdin_mutex);
-  if(stdin_fd && *stdin_fd != NULL) {
-    CloseHandle(*stdin_fd);
+  if(stdin_fd) {
+    if(*stdin_fd!=NULL) CloseHandle(*stdin_fd);
     stdin_fd.reset();
   }
 }


### PR DESCRIPTION
…zed handle, when CreateProcess fails.

Usually not an issue, but when on DEBUG mode, an exception is raised.

When CreateProcess fails, `stdin_fd`, `stdout_fd` and `stderr_fd` are left owning a not initialized `fd_type`.
Later, clean up, they are evaluated, and being true it assumes they must be closed.