### PR TITLE
Fixed examples and tests for windows without MSYS2 (Unicode and multi)

### DIFF
--- a/examples.cpp
+++ b/examples.cpp
@@ -3,9 +3,17 @@
 
 using namespace std;
 
+#if !defined(_WIN32) || defined(MSYS_PROCESS_USE_SH)
+const string PREFIX = "";
+const string SLEEP = "sleep";
+#else
+const string PREFIX = "cmd /C ";
+const string SLEEP = "timeout";
+#endif
+
 int main() {
   cout << "Example 1 - the mandatory Hello World" << endl;
-  Process process1("echo Hello World", "", [](const char *bytes, size_t n) {
+  Process process1(PREFIX+"echo Hello World", "", [](const char *bytes, size_t n) {
     cout << "Output from stdout: " << std::string(bytes, n);
   });
   auto exit_status=process1.get_exit_status();
@@ -14,7 +22,7 @@ int main() {
   
   
   cout << endl << "Example 2 - cd into a nonexistent directory" << endl;
-  Process process2("cd a_nonexistent_directory", "", [](const char *bytes, size_t n) {
+  Process process2(PREFIX+"cd a_nonexistent_directory", "", [](const char *bytes, size_t n) {
     cout << "Output from stdout: " << std::string(bytes, n);
   }, [](const char *bytes, size_t n) {
     cout << "Output from stderr: " << std::string(bytes, n);
@@ -29,7 +37,7 @@ int main() {
   
   cout << endl << "Example 3 - async sleep process" << endl;
   std::thread thread3([]() {
-    Process process3("sleep 5");
+    Process process3(SLEEP+" 5");
     auto exit_status=process3.get_exit_status();
     cout << "Example 3 process returned: " << exit_status << " (" << (exit_status==0?"success":"failure") << ")" << endl;
   });
@@ -38,7 +46,7 @@ int main() {
   
   
   cout << endl << "Example 4 - killing async sleep process after 5 seconds" << endl;
-  auto process4=std::make_shared<Process>("sleep 10");
+  auto process4=std::make_shared<Process>(SLEEP+" 10");
   std::thread thread4([process4]() {
     auto exit_status=process4->get_exit_status();
     cout << "Example 4 process returned: " << exit_status << " (" << (exit_status==0?"success":"failure") << ")" << endl;

--- a/process.cpp
+++ b/process.cpp
@@ -1,6 +1,6 @@
 #include "process.hpp"
 
-Process::Process(const string_type &command, const string_type &path,
+Process::Process(const std::string &command, const std::string &path,
                  std::function<void(const char* bytes, size_t n)> read_stdout,
                  std::function<void(const char* bytes, size_t n)> read_stderr,
                  bool open_stdin, size_t buffer_size):

--- a/process.hpp
+++ b/process.hpp
@@ -21,15 +21,9 @@ public:
 #ifdef _WIN32
   typedef unsigned long id_type; //Process id type
   typedef void *fd_type; //File descriptor type
-#ifdef UNICODE
-  typedef std::wstring string_type;
-#else
-  typedef std::string string_type;
-#endif
 #else
   typedef pid_t id_type;
   typedef int fd_type;
-  typedef std::string string_type;
 #endif
 private:
   class Data {
@@ -41,7 +35,7 @@ private:
 #endif
   };
 public:
-  Process(const string_type &command, const string_type &path=string_type(),
+  Process(const std::string &command, const std::string &path="",
           std::function<void(const char *bytes, size_t n)> read_stdout=nullptr,
           std::function<void(const char *bytes, size_t n)> read_stderr=nullptr,
           bool open_stdin=false,
@@ -77,7 +71,7 @@ private:
   
   std::unique_ptr<fd_type> stdout_fd, stderr_fd, stdin_fd;
   
-  id_type open(const string_type &command, const string_type &path);
+  id_type open(const std::string &command, const std::string &path);
   void async_read();
   void close_fds();
 };

--- a/process_win.cpp
+++ b/process_win.cpp
@@ -34,7 +34,7 @@ namespace {
 }
 
 //Based on the example at https://msdn.microsoft.com/en-us/library/windows/desktop/ms682499(v=vs.85).aspx.
-Process::id_type Process::open(const string_type &command, const string_type &path) {
+Process::id_type Process::open(const std::string &command, const std::string &path) {
   if(open_stdin)
     stdin_fd=std::unique_ptr<fd_type>(new fd_type(NULL));
   if(read_stdout)
@@ -75,27 +75,27 @@ Process::id_type Process::open(const string_type &command, const string_type &pa
   }
 
   PROCESS_INFORMATION process_info;
-  STARTUPINFO startup_info;
+  STARTUPINFOA startup_info;
 
   ZeroMemory(&process_info, sizeof(PROCESS_INFORMATION));
 
-  ZeroMemory(&startup_info, sizeof(STARTUPINFO));
-  startup_info.cb = sizeof(STARTUPINFO);
+  ZeroMemory(&startup_info, sizeof(STARTUPINFOA));
+  startup_info.cb = sizeof(STARTUPINFOA);
   startup_info.hStdInput = stdin_rd_p;
   startup_info.hStdOutput = stdout_wr_p;
   startup_info.hStdError = stderr_wr_p;
   if(stdin_fd || stdout_fd || stderr_fd)
     startup_info.dwFlags |= STARTF_USESTDHANDLES;
 
-  string_type process_command=command;
+  std::string process_command=command;
 #ifdef MSYS_PROCESS_USE_SH
   size_t pos=0;
-  while((pos=process_command.find('\\', pos))!=string_type::npos) {
+  while((pos=process_command.find('\\', pos))!= std::string::npos) {
     process_command.replace(pos, 1, "\\\\\\\\");
     pos+=4;
   }
   pos=0;
-  while((pos=process_command.find('\"', pos))!=string_type::npos) {
+  while((pos=process_command.find('\"', pos))!= std::string::npos) {
     process_command.replace(pos, 1, "\\\"");
     pos+=2;
   }
@@ -103,7 +103,7 @@ Process::id_type Process::open(const string_type &command, const string_type &pa
   process_command+="\"";
 #endif
 
-  BOOL bSuccess = CreateProcess(NULL, process_command.empty()?NULL:&process_command[0], NULL, NULL, TRUE, 0,
+  BOOL bSuccess = CreateProcessA(NULL, process_command.empty()?NULL:&process_command[0], NULL, NULL, TRUE, 0,
                                 NULL, path.empty()?NULL:path.c_str(), &startup_info, &process_info);
 
   if(!bSuccess) {

--- a/test/multithread_test.cpp
+++ b/test/multithread_test.cpp
@@ -5,6 +5,14 @@
 
 using namespace std;
 
+#if !defined(_WIN32) || defined(MSYS_PROCESS_USE_SH)
+const string PREFIX = "";
+const char* EOL = "\n";
+#else
+const string PREFIX = "cmd /C ";
+const char* EOL = "\r\n";
+#endif
+
 int main() {
   atomic<bool> stdout_error(false);
   atomic<bool> exit_status_error(false);
@@ -12,8 +20,8 @@ int main() {
   for(size_t ct=0;ct<4;ct++) {
     threads.emplace_back([&stdout_error, &exit_status_error, ct]() {
       for(size_t c=0;c<2500;c++) {
-        Process process("echo Hello World "+std::to_string(c)+" "+std::to_string(ct), "", [&stdout_error, ct, c](const char *bytes, size_t n) {
-          if(std::string(bytes, n)!="Hello World "+std::to_string(c)+" "+std::to_string(ct)+"\n")
+        Process process(PREFIX+"echo Hello World "+std::to_string(c)+" "+std::to_string(ct), "", [&stdout_error, ct, c](const char *bytes, size_t n) {
+          if(std::string(bytes, n)!="Hello World "+std::to_string(c)+" "+std::to_string(ct)+EOL)
             stdout_error=true;
         }, [](const char *bytes, size_t n) {
         }, true);

--- a/test/open_close_test.cpp
+++ b/test/open_close_test.cpp
@@ -3,11 +3,19 @@
 
 using namespace std;
 
+#if !defined(_WIN32) || defined(MSYS_PROCESS_USE_SH)
+const string PREFIX = "";
+const char* EOL = "\n";
+#else
+const string PREFIX = "cmd /C ";
+const char* EOL = "\r\n";
+#endif
+
 int main() {
   bool stdout_error=false;
   for(size_t c=0;c<10000;c++) {
-    Process process("echo Hello World "+std::to_string(c), "", [&stdout_error, c](const char *bytes, size_t n) {
-      if(std::string(bytes, n)!="Hello World "+std::to_string(c)+"\n")
+    Process process(PREFIX+"echo Hello World "+std::to_string(c), "", [&stdout_error, c](const char *bytes, size_t n) {
+      if(std::string(bytes, n)!="Hello World "+std::to_string(c)+EOL)
         stdout_error=true;
     }, [](const char *bytes, size_t n) {
     }, true);


### PR DESCRIPTION
Hi, I made some changes to tests and examples for them to run on Windows without MSYS2. On both Unicode and multi-byte.
As you can see, on Windows commands like `echo` or `cd` are _internal_  to `cmd.exe`, so you need to launch cmd process.
But `timeout` (somehow equivalent to `sleep`) is not internal, so no `cmd` needed.
Unicode support requires using windows `TEXT()` macro for literals to support both cases. And choose between `std::to_string` or `std::to_wstring`.