### PR TITLE
Add missing standard library include

### DIFF
--- a/process.hpp
+++ b/process.hpp
@@ -7,6 +7,7 @@
 #include <mutex>
 #include <thread>
 #include <mutex>
+#include <memory>
 #ifndef _WIN32
 #include <sys/wait.h>
 #endif

--- a/process.hpp
+++ b/process.hpp
@@ -6,7 +6,6 @@
 #include <vector>
 #include <mutex>
 #include <thread>
-#include <mutex>
 #include <memory>
 #ifndef _WIN32
 #include <sys/wait.h>


### PR DESCRIPTION
Process.hpp references std::unique_ptr which is defined in `<memory>`.
`<memory>` was missing while `<mutex>` was included twice. Maybe a bad merge?