### PR TITLE
Small code modernization changes.

### DIFF
--- a/process_unix.cpp
+++ b/process_unix.cpp
@@ -8,11 +8,11 @@ Process::Data::Data(): id(-1) {}
 
 Process::id_type Process::open(const std::string &command, const std::string &path) {
   if(open_stdin)
-    stdin_fd=std::unique_ptr<fd_type>(new fd_type);
+    stdin_fd=std::make_unique<fd_type>();
   if(read_stdout)
-    stdout_fd=std::unique_ptr<fd_type>(new fd_type);
+    stdout_fd=std::make_unique<fd_type>();
   if(read_stderr)
-    stderr_fd=std::unique_ptr<fd_type>(new fd_type);
+    stderr_fd=std::make_unique<fd_type>();
   
   int stdin_p[2], stdout_p[2], stderr_p[2];
 

--- a/process_unix.cpp
+++ b/process_unix.cpp
@@ -91,18 +91,18 @@ void Process::async_read() {
     return;
   if(stdout_fd) {
     stdout_thread=std::thread([this](){
-      char buffer[buffer_size];
+      auto buffer = std::make_unique<char[]>(buffer_size);
       ssize_t n;
-      while ((n=read(*stdout_fd, buffer, buffer_size)) > 0)
-        read_stdout(buffer, static_cast<size_t>(n));
+      while ((n=read(*stdout_fd, buffer.get(), buffer_size)) > 0)
+        read_stdout(buffer.get(), static_cast<size_t>(n));
     });
   }
   if(stderr_fd) {
     stderr_thread=std::thread([this](){
-      char buffer[buffer_size];
+      auto buffer = std::make_unique<char[]>(buffer_size);
       ssize_t n;
-      while ((n=read(*stderr_fd, buffer, buffer_size)) > 0)
-        read_stderr(buffer, static_cast<size_t>(n));
+      while ((n=read(*stderr_fd, buffer.get(), buffer_size)) > 0)
+        read_stderr(buffer.get(), static_cast<size_t>(n));
     });
   }
 }

--- a/process_unix.cpp
+++ b/process_unix.cpp
@@ -91,7 +91,7 @@ void Process::async_read() {
     return;
   if(stdout_fd) {
     stdout_thread=std::thread([this](){
-      auto buffer = std::make_unique<char[]>(buffer_size);
+      auto buffer = std::unique_ptr<char[]>( new char[buffer_size] );
       ssize_t n;
       while ((n=read(*stdout_fd, buffer.get(), buffer_size)) > 0)
         read_stdout(buffer.get(), static_cast<size_t>(n));
@@ -99,7 +99,7 @@ void Process::async_read() {
   }
   if(stderr_fd) {
     stderr_thread=std::thread([this](){
-      auto buffer = std::make_unique<char[]>(buffer_size);
+      auto buffer = std::unique_ptr<char[]>( new char[buffer_size] );
       ssize_t n;
       while ((n=read(*stderr_fd, buffer.get(), buffer_size)) > 0)
         read_stderr(buffer.get(), static_cast<size_t>(n));

--- a/process_unix.cpp
+++ b/process_unix.cpp
@@ -8,11 +8,11 @@ Process::Data::Data(): id(-1) {}
 
 Process::id_type Process::open(const std::string &command, const std::string &path) {
   if(open_stdin)
-    stdin_fd=std::make_unique<fd_type>();
+    stdin_fd=std::unique_ptr<fd_type>(new fd_type);
   if(read_stdout)
-    stdout_fd=std::make_unique<fd_type>();
+    stdout_fd=std::unique_ptr<fd_type>(new fd_type);
   if(read_stderr)
-    stderr_fd=std::make_unique<fd_type>();
+    stderr_fd=std::unique_ptr<fd_type>(new fd_type);
   
   int stdin_p[2], stdout_p[2], stderr_p[2];
 

--- a/process_win.cpp
+++ b/process_win.cpp
@@ -36,11 +36,11 @@ namespace {
 //Based on the example at https://msdn.microsoft.com/en-us/library/windows/desktop/ms682499(v=vs.85).aspx.
 Process::id_type Process::open(const string_type &command, const string_type &path) {
   if(open_stdin)
-    stdin_fd=std::make_unique<fd_type>(NULL);
+    stdin_fd=std::unique_ptr<fd_type>(new fd_type(NULL));
   if(read_stdout)
-    stdout_fd=std::make_unique<fd_type>(NULL);
+    stdout_fd=std::unique_ptr<fd_type>(new fd_type(NULL));
   if(read_stderr)
-    stderr_fd=std::make_unique<fd_type>(NULL);
+    stderr_fd=std::unique_ptr<fd_type>(new fd_type(NULL));
 
   Handle stdin_rd_p;
   Handle stdin_wr_p;
@@ -131,7 +131,7 @@ void Process::async_read() {
   if(stdout_fd) {
     stdout_thread=std::thread([this](){
       DWORD n;
-      auto buffer = std::make_unique<char[]>(buffer_size);
+      std::unique_ptr<char[]> buffer(new char[buffer_size]);
       for (;;) {
         BOOL bSuccess = ReadFile(*stdout_fd, static_cast<CHAR*>(buffer.get()), static_cast<DWORD>(buffer_size), &n, nullptr);
         if(!bSuccess || n == 0)
@@ -143,7 +143,7 @@ void Process::async_read() {
   if(stderr_fd) {
     stderr_thread=std::thread([this](){
       DWORD n;
-      auto buffer = std::make_unique<char[]>(buffer_size);
+      std::unique_ptr<char[]> buffer(new char[buffer_size]);
       for (;;) {
         BOOL bSuccess = ReadFile(*stderr_fd, static_cast<CHAR*>(buffer.get()), static_cast<DWORD>(buffer_size), &n, nullptr);
         if(!bSuccess || n == 0)

--- a/process_win.cpp
+++ b/process_win.cpp
@@ -36,11 +36,11 @@ namespace {
 //Based on the example at https://msdn.microsoft.com/en-us/library/windows/desktop/ms682499(v=vs.85).aspx.
 Process::id_type Process::open(const string_type &command, const string_type &path) {
   if(open_stdin)
-    stdin_fd=std::unique_ptr<fd_type>(new fd_type(NULL));
+    stdin_fd=std::make_unique<fd_type>(NULL);
   if(read_stdout)
-    stdout_fd=std::unique_ptr<fd_type>(new fd_type(NULL));
+    stdout_fd=std::make_unique<fd_type>(NULL);
   if(read_stderr)
-    stderr_fd=std::unique_ptr<fd_type>(new fd_type(NULL));
+    stderr_fd=std::make_unique<fd_type>(NULL);
 
   Handle stdin_rd_p;
   Handle stdin_wr_p;
@@ -131,7 +131,7 @@ void Process::async_read() {
   if(stdout_fd) {
     stdout_thread=std::thread([this](){
       DWORD n;
-      std::unique_ptr<char[]> buffer(new char[buffer_size]);
+      auto buffer = std::make_unique<char[]>(buffer_size);
       for (;;) {
         BOOL bSuccess = ReadFile(*stdout_fd, static_cast<CHAR*>(buffer.get()), static_cast<DWORD>(buffer_size), &n, NULL);
         if(!bSuccess || n == 0)
@@ -143,7 +143,7 @@ void Process::async_read() {
   if(stderr_fd) {
     stderr_thread=std::thread([this](){
       DWORD n;
-      std::unique_ptr<char[]> buffer(new char[buffer_size]);
+      auto buffer = std::make_unique<char[]>(buffer_size);
       for (;;) {
         BOOL bSuccess = ReadFile(*stderr_fd, static_cast<CHAR*>(buffer.get()), static_cast<DWORD>(buffer_size), &n, NULL);
         if(!bSuccess || n == 0)

--- a/process_win.cpp
+++ b/process_win.cpp
@@ -53,7 +53,7 @@ Process::id_type Process::open(const string_type &command, const string_type &pa
 
   security_attributes.nLength = sizeof(SECURITY_ATTRIBUTES);
   security_attributes.bInheritHandle = TRUE;
-  security_attributes.lpSecurityDescriptor = NULL;
+  security_attributes.lpSecurityDescriptor = nullptr;
 
   std::lock_guard<std::mutex> lock(create_process_mutex);
   if(stdin_fd) {
@@ -103,8 +103,8 @@ Process::id_type Process::open(const string_type &command, const string_type &pa
   process_command+="\"";
 #endif
 
-  BOOL bSuccess = CreateProcess(NULL, process_command.empty()?NULL:&process_command[0], NULL, NULL, TRUE, 0,
-                                NULL, path.empty()?NULL:path.c_str(), &startup_info, &process_info);
+  BOOL bSuccess = CreateProcess(nullptr, process_command.empty()?nullptr:&process_command[0], nullptr, nullptr, TRUE, 0,
+                                nullptr, path.empty()?nullptr:path.c_str(), &startup_info, &process_info);
 
   if(!bSuccess) {
     CloseHandle(process_info.hProcess);
@@ -133,7 +133,7 @@ void Process::async_read() {
       DWORD n;
       auto buffer = std::make_unique<char[]>(buffer_size);
       for (;;) {
-        BOOL bSuccess = ReadFile(*stdout_fd, static_cast<CHAR*>(buffer.get()), static_cast<DWORD>(buffer_size), &n, NULL);
+        BOOL bSuccess = ReadFile(*stdout_fd, static_cast<CHAR*>(buffer.get()), static_cast<DWORD>(buffer_size), &n, nullptr);
         if(!bSuccess || n == 0)
           break;
         read_stdout(buffer.get(), static_cast<size_t>(n));
@@ -145,7 +145,7 @@ void Process::async_read() {
       DWORD n;
       auto buffer = std::make_unique<char[]>(buffer_size);
       for (;;) {
-        BOOL bSuccess = ReadFile(*stderr_fd, static_cast<CHAR*>(buffer.get()), static_cast<DWORD>(buffer_size), &n, NULL);
+        BOOL bSuccess = ReadFile(*stderr_fd, static_cast<CHAR*>(buffer.get()), static_cast<DWORD>(buffer_size), &n, nullptr);
         if(!bSuccess || n == 0)
           break;
         read_stderr(buffer.get(), static_cast<size_t>(n));
@@ -196,7 +196,7 @@ bool Process::write(const char *bytes, size_t n) {
   std::lock_guard<std::mutex> lock(stdin_mutex);
   if(stdin_fd) {
     DWORD written;
-    BOOL bSuccess=WriteFile(*stdin_fd, bytes, static_cast<DWORD>(n), &written, NULL);
+    BOOL bSuccess=WriteFile(*stdin_fd, bytes, static_cast<DWORD>(n), &written, nullptr);
     if(!bSuccess || written==0) {
       return false;
     }


### PR DESCRIPTION
I suggest replacing the C99 VLA usage with a dynamic buffer (as done in commit [7eda337](https://github.com/eidheim/tiny-process-library/commit/7eda3373701cdbd5724910083f8b791d8461ecb7) ) since there are still important C++ compilers who do not seem to support C99 (like some versions of MSVC/Visual Studio).

I also replaced all occurrences of `operator new` since raw usage of it is discouraged; `std::make_unique<>` does the job just fine in this case.

Finally, I replaced C-Style `NULL` macro usage in WinAPI calls with modern C++'s `nullptr.`

Feel free to cherry pick if you do not like the VLA change.