### PR TITLE
Add cmake installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,13 @@ script:
       apt-get update &&
       apt-get install --yes cmake make g\+\+ clang perl &&
       cd /repository && mkdir build && cd build &&
-      scan-build cmake -DENABLE_TESTING=1 -DCMAKE_CXX_FLAGS=-Werror .. &&
+      scan-build cmake -DBUILD_TESTING=1 -DCMAKE_CXX_FLAGS=-Werror .. &&
       scan-build --status-bugs make &&
       rm -r * &&
-      CXX=clang++ cmake -DENABLE_TESTING=1 -DCMAKE_CXX_FLAGS=-Werror .. &&
+      CXX=clang++ cmake -DBUILD_TESTING=1 -DCMAKE_CXX_FLAGS=-Werror .. &&
       make &&
       rm -r * &&
-      CXX=g++ cmake -DENABLE_TESTING=1 -DCMAKE_CXX_FLAGS=-Werror .. &&
+      CXX=g++ cmake -DBUILD_TESTING=1 -DCMAKE_CXX_FLAGS=-Werror .. &&
       make &&
       CTEST_OUTPUT_ON_FAILURE=1 make test
       "

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,13 +23,45 @@ else()
 endif()
 
 add_library(tiny-process-library ${process_source_files})
-add_executable(examples examples.cpp)
 
 target_link_libraries(tiny-process-library ${CMAKE_THREAD_LIBS_INIT})
+target_include_directories(tiny-process-library PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/.>)
+target_include_directories(tiny-process-library SYSTEM INTERFACE $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include>)
+
+# Installation
+install(TARGETS tiny-process-library 
+  EXPORT tiny-process-library-targets
+  DESTINATION lib)
+install(FILES process.hpp DESTINATION include)
+
+set(CONFIG_PACKAGE_INSTALL_DIR lib/cmake/tiny-process-library)
+include(CMakePackageConfigHelpers)
+
+write_basic_package_version_file(
+  ${CMAKE_CURRENT_BINARY_DIR}/tiny-process-library-config-version.cmake
+  VERSION 1.0.7
+  COMPATIBILITY SameMajorVersion
+)
+
+install(EXPORT tiny-process-library-targets
+  DESTINATION
+    ${CONFIG_PACKAGE_INSTALL_DIR}
+)
+
+install(FILES
+  ${CMAKE_CURRENT_SOURCE_DIR}/tiny-process-library-config.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/tiny-process-library-config-version.cmake
+  DESTINATION
+    ${CONFIG_PACKAGE_INSTALL_DIR} )
+
+# Build examples
+add_executable(examples examples.cpp)
 target_link_libraries(examples tiny-process-library)
 
-# To enable tests: cmake -DENABLE_TESTING=1 .
-if(ENABLE_TESTING)
+option(BUILD_TESTING Off)
+
+# To enable tests: cmake -DBUILD_TESTING=1 .
+if(BUILD_TESTING)
   enable_testing()
   add_subdirectory(tests)
 endif()

--- a/tiny-process-library-config.cmake
+++ b/tiny-process-library-config.cmake
@@ -1,0 +1,1 @@
+include("${CMAKE_CURRENT_LIST_DIR}/tiny-process-library-targets.cmake")


### PR DESCRIPTION
* Add installation step to cmake
* Install cmake configuration so the user can do `find_package(tiny-process-library)` and then use the `tiny-process-library` target.
* Use `BUILD_TESTING` variable to enable tests as that is the variable used by ctest to enable tests.