### PR TITLE
implement is_running()

### DIFF
--- a/examples.cpp
+++ b/examples.cpp
@@ -107,13 +107,13 @@ int main() {
   
   Process process8("sleep 5");
   int exit_status_p8;
-  cout << "Example 8 running: " << (process8.try_get_exit_status(exit_status_p8) ? "yes" : "no") << endl;
+  cout << "Example 8 process running: " << (process8.try_get_exit_status(exit_status_p8) ? "no" : "yes") << endl;
   this_thread::sleep_for(chrono::seconds(2));
-  cout << "Example 8 running: " << (process8.try_get_exit_status(exit_status_p8) ? "yes" : "no") << endl;
+  cout << "Example 8 process running: " << (process8.try_get_exit_status(exit_status_p8) ? "no" : "yes") << endl;
   this_thread::sleep_for(chrono::seconds(2));
-  cout << "Example 8 running: " << (process8.try_get_exit_status(exit_status_p8) ? "yes" : "no") << endl;
+  cout << "Example 8 process running: " << (process8.try_get_exit_status(exit_status_p8) ? "no" : "yes") << endl;
   this_thread::sleep_for(chrono::seconds(2));
-  cout << "Example 8 running: " << (process8.try_get_exit_status(exit_status_p8) ? "yes" : "no") << endl;
+  cout << "Example 8 process running: " << (process8.try_get_exit_status(exit_status_p8) ? "no" : "yes") << endl;
   cout << "Example 8 process returned: " << exit_status_p8 << " (" << (exit_status_p8==0?"success":"failure") << ")" << endl;
 
 #else
@@ -168,13 +168,13 @@ int main() {
 
   Process process5("timeout 5");
   int exit_status_p5;
-  cout << "Example 5 running: " << (process5.try_get_exit_status(exit_status_p5)? "yes" : "no") << endl;
+  cout << "Example 5 running: " << (process5.try_get_exit_status(exit_status_p5)? "no" : "yes") << endl;
   this_thread::sleep_for(chrono::seconds(2));
-  cout << "Example 5 running: " << (process5.try_get_exit_status(exit_status_p5)? "yes" : "no") << endl;
+  cout << "Example 5 running: " << (process5.try_get_exit_status(exit_status_p5)? "no" : "yes") << endl;
   this_thread::sleep_for(chrono::seconds(2));
-  cout << "Example 5 running: " << (process5.try_get_exit_status(exit_status_p5)? "yes" : "no") << endl;
+  cout << "Example 5 running: " << (process5.try_get_exit_status(exit_status_p5)? "no" : "yes") << endl;
   this_thread::sleep_for(chrono::seconds(2));
-  cout << "Example 5 running: " << (process5.try_get_exit_status(exit_status_p5)? "yes" : "no") << endl;
+  cout << "Example 5 running: " << (process5.try_get_exit_status(exit_status_p5)? "no" : "yes") << endl;
   cout << "Example 5 process returned: " << exit_status_p5 << " (" << (exit_status_p5==0?"success":"failure") << ")" << endl;
 
 

--- a/examples.cpp
+++ b/examples.cpp
@@ -103,6 +103,18 @@ int main() {
   cout << "Example 7 process returned: " << exit_status << " (" << (exit_status==0?"success":"failure") << ")" << endl;
   this_thread::sleep_for(chrono::seconds(5));
 
+  cout << endl << "Example 8 - async try get exit status" << endl;
+  
+  Process process8("sleep 5");
+  int exit_status_p8;
+  cout << "Example 8 running: " << (process8.try_get_exit_status(&exit_status_p8) ? "yes" : "no") << endl;
+  this_thread::sleep_for(chrono::seconds(2));
+  cout << "Example 8 running: " << (process8.try_get_exit_status(&exit_status_p8) ? "yes" : "no") << endl;
+  this_thread::sleep_for(chrono::seconds(2));
+  cout << "Example 8 running: " << (process8.try_get_exit_status(&exit_status_p8) ? "yes" : "no") << endl;
+  this_thread::sleep_for(chrono::seconds(2));
+  cout << "Example 8 running: " << (process8.try_get_exit_status(&exit_status_p8) ? "yes" : "no") << endl;
+  cout << "Example 8 process returned: " << exit_status_p8 << " (" << (exit_status_p8==0?"success":"failure") << ")" << endl;
 
 #else
   //Examples for Windows without MSYS2
@@ -151,6 +163,19 @@ int main() {
   this_thread::sleep_for(chrono::seconds(5));
   process4->kill();
   this_thread::sleep_for(chrono::seconds(5));
+
+  cout << endl << "Example 5 - async try get exit status" << endl;
+
+  Process process5("timeout 5");
+  int exit_status_p5;
+  cout << "Example 5 running: " << (process5.try_get_exit_status(&exit_status_p5)? "yes" : "no") << endl;
+  this_thread::sleep_for(chrono::seconds(2));
+  cout << "Example 5 running: " << (process5.try_get_exit_status(&exit_status_p5)? "yes" : "no") << endl;
+  this_thread::sleep_for(chrono::seconds(2));
+  cout << "Example 5 running: " << (process5.try_get_exit_status(&exit_status_p5)? "yes" : "no") << endl;
+  this_thread::sleep_for(chrono::seconds(2));
+  cout << "Example 5 running: " << (process5.try_get_exit_status(&exit_status_p5)? "yes" : "no") << endl;
+  cout << "Example 5 process returned: " << exit_status_p5 << " (" << (exit_status_p5==0?"success":"failure") << ")" << endl;
 
 
 #endif

--- a/examples.cpp
+++ b/examples.cpp
@@ -107,13 +107,13 @@ int main() {
   
   Process process8("sleep 5");
   int exit_status_p8;
-  cout << "Example 8 running: " << (process8.try_get_exit_status(&exit_status_p8) ? "yes" : "no") << endl;
+  cout << "Example 8 running: " << (process8.try_get_exit_status(exit_status_p8) ? "yes" : "no") << endl;
   this_thread::sleep_for(chrono::seconds(2));
-  cout << "Example 8 running: " << (process8.try_get_exit_status(&exit_status_p8) ? "yes" : "no") << endl;
+  cout << "Example 8 running: " << (process8.try_get_exit_status(exit_status_p8) ? "yes" : "no") << endl;
   this_thread::sleep_for(chrono::seconds(2));
-  cout << "Example 8 running: " << (process8.try_get_exit_status(&exit_status_p8) ? "yes" : "no") << endl;
+  cout << "Example 8 running: " << (process8.try_get_exit_status(exit_status_p8) ? "yes" : "no") << endl;
   this_thread::sleep_for(chrono::seconds(2));
-  cout << "Example 8 running: " << (process8.try_get_exit_status(&exit_status_p8) ? "yes" : "no") << endl;
+  cout << "Example 8 running: " << (process8.try_get_exit_status(exit_status_p8) ? "yes" : "no") << endl;
   cout << "Example 8 process returned: " << exit_status_p8 << " (" << (exit_status_p8==0?"success":"failure") << ")" << endl;
 
 #else
@@ -168,13 +168,13 @@ int main() {
 
   Process process5("timeout 5");
   int exit_status_p5;
-  cout << "Example 5 running: " << (process5.try_get_exit_status(&exit_status_p5)? "yes" : "no") << endl;
+  cout << "Example 5 running: " << (process5.try_get_exit_status(exit_status_p5)? "yes" : "no") << endl;
   this_thread::sleep_for(chrono::seconds(2));
-  cout << "Example 5 running: " << (process5.try_get_exit_status(&exit_status_p5)? "yes" : "no") << endl;
+  cout << "Example 5 running: " << (process5.try_get_exit_status(exit_status_p5)? "yes" : "no") << endl;
   this_thread::sleep_for(chrono::seconds(2));
-  cout << "Example 5 running: " << (process5.try_get_exit_status(&exit_status_p5)? "yes" : "no") << endl;
+  cout << "Example 5 running: " << (process5.try_get_exit_status(exit_status_p5)? "yes" : "no") << endl;
   this_thread::sleep_for(chrono::seconds(2));
-  cout << "Example 5 running: " << (process5.try_get_exit_status(&exit_status_p5)? "yes" : "no") << endl;
+  cout << "Example 5 running: " << (process5.try_get_exit_status(exit_status_p5)? "yes" : "no") << endl;
   cout << "Example 5 process returned: " << exit_status_p5 << " (" << (exit_status_p5==0?"success":"failure") << ")" << endl;
 
 

--- a/process.hpp
+++ b/process.hpp
@@ -62,7 +62,7 @@ public:
   ///Wait until process is finished, and return exit status.
   int get_exit_status() noexcept;
   ///Check if the process has finished, return true and set the exit status otherwise return false
-  bool try_get_exit_status(int* exit_status) noexcept;
+  bool try_get_exit_status(int *exit_status) noexcept;
   ///Write to stdin.
   bool write(const char *bytes, size_t n);
   ///Write to stdin. Convenience function using write(const char *, size_t).

--- a/process.hpp
+++ b/process.hpp
@@ -62,7 +62,7 @@ public:
   ///Wait until process is finished, and return exit status.
   int get_exit_status() noexcept;
   ///Check if the process has finished, return true and set the exit status otherwise return false
-  bool try_get_exit_status(int *exit_status) noexcept;
+  bool try_get_exit_status(int &exit_status) noexcept;
   ///Write to stdin.
   bool write(const char *bytes, size_t n);
   ///Write to stdin. Convenience function using write(const char *, size_t).

--- a/process.hpp
+++ b/process.hpp
@@ -61,6 +61,8 @@ public:
   id_type get_id() const noexcept;
   ///Wait until process is finished, and return exit status.
   int get_exit_status() noexcept;
+  ///Check if the process has finished, return true and set the exit status otherwise return false
+  bool try_get_exit_status(int* exit_status) noexcept;
   ///Write to stdin.
   bool write(const char *bytes, size_t n);
   ///Write to stdin. Convenience function using write(const char *, size_t).

--- a/process_unix.cpp
+++ b/process_unix.cpp
@@ -137,6 +137,22 @@ int Process::get_exit_status() noexcept {
   return exit_status;
 }
 
+bool Process::try_get_exit_status(int* exit_status) noexcept {
+  if(data.id<=0)
+    return false;
+  id_type p = waitpid(data.id, exit_status, WNOHANG);
+  if (p == data.id) {
+    {
+        std::lock_guard<std::mutex> lock(close_mutex);
+        closed=true;
+    }
+    close_fds();
+    if(*exit_status>=256)
+        *exit_status=*exit_status>>8;
+  }
+  return p == 0;
+}
+
 void Process::close_fds() noexcept {
   if(stdout_thread.joinable())
     stdout_thread.join();

--- a/process_unix.cpp
+++ b/process_unix.cpp
@@ -141,16 +141,19 @@ bool Process::try_get_exit_status(int &exit_status) noexcept {
   if(data.id<=0)
     return false;
   id_type p = waitpid(data.id, &exit_status, WNOHANG);
-  if (p == data.id) {
-    {
-        std::lock_guard<std::mutex> lock(close_mutex);
-        closed=true;
-    }
-    close_fds();
-    if(exit_status>=256)
-        exit_status=exit_status>>8;
+
+  if (p == 0)
+    return false;
+
+  {
+    std::lock_guard<std::mutex> lock(close_mutex);
+    closed=true;
   }
-  return p == 0;
+  close_fds();
+  if(exit_status>=256)
+    exit_status=exit_status>>8;
+
+  return true;
 }
 
 void Process::close_fds() noexcept {

--- a/process_unix.cpp
+++ b/process_unix.cpp
@@ -137,18 +137,18 @@ int Process::get_exit_status() noexcept {
   return exit_status;
 }
 
-bool Process::try_get_exit_status(int *exit_status) noexcept {
+bool Process::try_get_exit_status(int &exit_status) noexcept {
   if(data.id<=0)
     return false;
-  id_type p = waitpid(data.id, exit_status, WNOHANG);
+  id_type p = waitpid(data.id, &exit_status, WNOHANG);
   if (p == data.id) {
     {
         std::lock_guard<std::mutex> lock(close_mutex);
         closed=true;
     }
     close_fds();
-    if(*exit_status>=256)
-        *exit_status=*exit_status>>8;
+    if(exit_status>=256)
+        exit_status=exit_status>>8;
   }
   return p == 0;
 }

--- a/process_unix.cpp
+++ b/process_unix.cpp
@@ -137,7 +137,7 @@ int Process::get_exit_status() noexcept {
   return exit_status;
 }
 
-bool Process::try_get_exit_status(int* exit_status) noexcept {
+bool Process::try_get_exit_status(int *exit_status) noexcept {
   if(data.id<=0)
     return false;
   id_type p = waitpid(data.id, exit_status, WNOHANG);

--- a/process_win.cpp
+++ b/process_win.cpp
@@ -171,7 +171,7 @@ int Process::get_exit_status() noexcept {
   return static_cast<int>(exit_status);
 }
 
-bool Process::try_get_exit_status(int* exit_status) noexcept {
+bool Process::try_get_exit_status(int *exit_status) noexcept {
   if(data.id==0)
     return false;
 

--- a/process_win.cpp
+++ b/process_win.cpp
@@ -171,7 +171,7 @@ int Process::get_exit_status() noexcept {
   return static_cast<int>(exit_status);
 }
 
-bool Process::try_get_exit_status(int *exit_status) noexcept {
+bool Process::try_get_exit_status(int &exit_status) noexcept {
   if(data.id==0)
     return false;
 
@@ -190,7 +190,7 @@ bool Process::try_get_exit_status(int *exit_status) noexcept {
   }
   close_fds();
 
-  *exit_status = static_cast<int>(exit_status_win);
+  exit_status = static_cast<int>(exit_status_win);
   return true;
 }
 


### PR DESCRIPTION
Implements a is_running() method to check whether a process is running. For some usecases this makes the observer thread unnecessary. 

For waitpid(unix) I had to cache the exit code, IMHO now it behave also more consistent as get_exit_status can be called multiple times. For windows it should work without this trick.

Windows implementation should work but needs to be tested.